### PR TITLE
Update Initialization Endpoint with Other Players Array

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ psycopg2-binary = "*"
 whitenoise = "*"
 
 [dev-packages]
+autopep8 = "*"
 
 [requires]
 python_version = "3.7.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a2ec7d7e519a05a7a02477d22af96aa7dc401154607980b4ae515ee0d1ac8806"
+            "sha256": "ebc1187459a0cecf6d049c3446795ffed6bc8ccf7d4b35953c9991bf3a2601d4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -356,5 +356,20 @@
             "version": "==4.1.4"
         }
     },
-    "develop": {}
+    "develop": {
+        "autopep8": {
+            "hashes": [
+                "sha256:4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"
+            ],
+            "index": "pypi",
+            "version": "==1.4.4"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        }
+    }
 }

--- a/adventure/api.py
+++ b/adventure/api.py
@@ -23,7 +23,13 @@ def initialize(request):
     player_id = player.id
     uuid = player.uuid
     room = Room.objects.get(id=player.currentRoom)
-    return JsonResponse({'player_uuid': uuid, "room_uuid": room.uuid, "player_id": player_id, 'player_name': player.user.username, "room_id": room.id, 'room_title': room.title, 'room_description': room.description}, safe=True)
+    other_players = []
+    players = Player.objects.all()
+    for p in players:
+        if p.currentRoom == player.currentRoom:
+            if p.id != player_id:
+                other_players.append(p.user.username)
+    return JsonResponse({'player_uuid': uuid, "room_uuid": room.uuid, "player_id": player_id, 'player_name': player.user.username, "room_id": room.id, 'room_title': room.title, 'room_description': room.description, "other_players": other_players}, safe=True)
 
 
 @csrf_exempt


### PR DESCRIPTION
This PR upgrades the `init/` endpoint to include an array of any other players currently in the starting room with the player.